### PR TITLE
To Fix iOS Bug where wrong image is shown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Forked Note:
+Original library was great in every manner. In iOS, there was a small bug that cropping new image returned old image path which showed incorrect image. To make file name unique and avoid name mismatch, adding intervalString as an extra layer in the file name for iOS and it solved problem (at least for me). Feel free to use forked version this if you're facing the same bug in the original library.
+
 # Cordova Image Cropper
 Cordova plugin for image cropping with custom aspect ratio.
 

--- a/src/ios/KImageCropper.m
+++ b/src/ios/KImageCropper.m
@@ -138,7 +138,10 @@
     // generate unique file name
     int i = 1;
     do {
-        filePath = [NSString stringWithFormat:@"%@/%@%03d.%@", docsPath, CDV_PHOTO_PREFIX, i++, extension];
+        // To make file name unique and avoid name mismatch, adding intervalString as an extra layer in the file name.
+        NSTimeInterval  today = [[NSDate date] timeIntervalSince1970];
+        NSString *intervalString = [NSString stringWithFormat:@"%f", today];
+        filePath = [NSString stringWithFormat:@"%@/%@%03d_%@.%@", docsPath, CDV_PHOTO_PREFIX, i++, intervalString , extension];
     } while ([fileMgr fileExistsAtPath:filePath]);
 
     return filePath;


### PR DESCRIPTION
Original library was great in every manner. In iOS, there was a small bug that cropping new image returned old image path which showed incorrect image. To make file name unique and avoid name mismatch, adding intervalString as an extra layer in the file name for iOS and it solved problem (at least for me). Feel free to use forked version this if you're facing the same bug in the original library.
